### PR TITLE
Use root project build tools version if present

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion "30.0.2"
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : "30.0.2"
 
     defaultConfig {
         minSdkVersion 21

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.4-5",
+  "version": "3.0.4-6",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
Resolves the following warning when using React Native `0.73` and above

```
WARNING: The specified Android SDK Build Tools version (30.0.2) is ignored, as it is below the minimum supported version (34.0.0) for Android Gradle Plugin 8.2.1.
```