### PR TITLE
Fix mTempFiles being null when inside a tab view on Android

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2280,6 +2280,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         // TODO, update base64 when ViewerBuilder supports byte array
         Uri fileUri = ReactUtils.getUri(getContext(), mDocumentPath, mIsBase64, mBase64Extension);
 
+        if (mTempFiles == null) {
+            mTempFiles = new ArrayList<>();
+        }
+
         if (fileUri != null) {
             if (mIsBase64) {
                 mTempFiles.add(new File(fileUri.getPath()));


### PR DESCRIPTION
When a DocumentView is inside of a BottomTabNavigator from `@react-navigation/bottom-tabs`, it will be detached from the window without being completely destroyed. The next time the user goes to the tab, the app will crash because mTempFiles was set to null inside of `onDetachedFromWindow`

https://github.com/ApryseSDK/pdftron-react-native/blob/642b7072f2f249414c63f94415f71b0ee8c0d624/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java#L2356

but onAttachedToWindow still tries to read it:

https://github.com/ApryseSDK/pdftron-react-native/blob/642b7072f2f249414c63f94415f71b0ee8c0d624/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java#L2285

To fix, I just added a safety check to make sure the field is initialized before use inside of `onAttachedToWindow`.