### PR TITLE
[iOS] Fix setStampImageData unrotating image annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.4-12",
+  "version": "3.0.4-13",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
Addresses an issue with a rotated image stamp that has called setStampImageData's which ended up unrotating an image that wasn't supposed to be rotated

![image](https://github.com/user-attachments/assets/31162af5-2f6b-4fd3-9520-879e368e0057)
